### PR TITLE
[#3] Set base layout with persistent navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@200;400&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import {createBrowserRouter, createRoutesFromElements, Outlet, Route, RouterProvider} from 'react-router-dom'
-
+import {createBrowserRouter, createRoutesFromElements, Route, RouterProvider} from 'react-router-dom'
+import RootLayout from "./layouts/RootLayout.jsx";
 
 const App = () => {
     const routes = createBrowserRouter(
         createRoutesFromElements(
-            <Route path="/" element={<Outlet />}>
+            <Route path="/" element={<RootLayout />}>
                 <Route index element={<div>Home temp</div>} />
                 <Route path="sign-up" element={<div>Sign Up temp</div>}/>
                 <Route path="login" element={<div>Login</div>}/>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import {Link} from "react-router-dom";
+
+const Navbar = () => {
+    return (
+        <div className="navbar">
+            <div/>
+            <Link to="/"><h1>Save Todo</h1></Link>
+            <Link to="sign-up"><button>Get Started</button></Link>
+        </div>
+    );
+};
+
+export default Navbar;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,36 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: "JetBrains Mono", monospace;
+}
+
+a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.navbar {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    height: 6.25rem;
+}
+
+.navbar h1 {
+    font-size: 2.5rem;
+    font-weight: normal;
+}
+
+.navbar button {
+    display: block;
+    justify-self: end;
+    font-size: 1.25rem;
+    width: 12.5rem;
+    height: 4.125rem;
+    background-color: #2FAAC5;
+    color: white;
+    border: none;
+    border-radius: 50px;
+    margin-right: 1rem;
+}

--- a/src/layouts/RootLayout.jsx
+++ b/src/layouts/RootLayout.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import {Outlet} from "react-router-dom";
+import Navbar from "../components/Navbar.jsx";
+
+const RootLayout = () => {
+    return (
+        <>
+            <Navbar />
+            <Outlet />
+        </>
+    );
+};
+
+export default RootLayout;


### PR DESCRIPTION
### ✅ What does this PR do?
This PR stablishes the main layout of the application, including a persistent navbar across all routes

---

### 📋 Related Issue(s)
Closes #3 

---

### 🛠 Changes made
- Added `Navbar `component
- Created `RootLayout `component and replaced `Outlet `in `/` route with it
- Applied styling to components
- Added JetBrains Mono font

---

### 📸 Screenshots (if applicable)
### Page Layout
<img width="2560" height="1352" alt="image" src="https://github.com/user-attachments/assets/1fcdd4f0-eea3-4357-a3ae-99edbae4d1de" />

---

### 🔎 How to test
1. Run `npm run dev`
2. Open http://localhost:5173/
3. Verify that:
    - The title is centered
    - The "Get Started" button is styled and aligned
    - The layout persists when navigating between `/`, `/sign-up`, `/login`
---

### 🧠 Notes
- The 'Get Started' button is currently visible on all routes. It will be conditionally hidden on /sign-up, /login, and potentially other routes in future branches.
