### PR TITLE
Add Login page UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {createBrowserRouter, createRoutesFromElements, Route, RouterProvider} from 'react-router-dom'
-import RootLayout from "./layouts/RootLayout.jsx";
-import SignUp from "./pages/SignUp.jsx";
+import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom'
+import RootLayout from './layouts/RootLayout.jsx';
+import SignUp from './pages/SignUp.jsx';
+import Login from './pages/Login.jsx';
 
 const App = () => {
     const routes = createBrowserRouter(
@@ -9,7 +10,7 @@ const App = () => {
             <Route path="/" element={<RootLayout />}>
                 <Route index element={<div>Home temp</div>} />
                 <Route path="sign-up" element={<SignUp />}/>
-                <Route path="login" element={<div>Login</div>}/>
+                <Route path="login" element={<Login />}/>
             </Route>
         )
     )

--- a/src/index.css
+++ b/src/index.css
@@ -36,14 +36,14 @@ a {
     margin-right: 1rem;
 }
 
-/* ---- SIGN UP PAGE ---- */
+/* ---- SIGN UP & LOGIN  ---- */
 
-.sign-up-page {
+.auth-page {
     height: 75vh;
     align-content: center;
 }
 
-.sign-up-div {
+.auth-container {
     width: 20.5rem;
     border: 1px black solid;
     border-radius: 10px;
@@ -51,17 +51,17 @@ a {
     padding: 1rem;
 }
 
-.sign-up-div h1 {
+.auth-container h1 {
     text-align: center;
     font-size: 2.25rem;
     margin-bottom: 2rem;
 }
 
-.form label {
+.auth-form label {
     font-size: 1.25rem;
 }
 
-.form input {
+.auth-form input {
     font-size: 1rem;
     border-radius: 7px;
     border-width: 1px;
@@ -71,7 +71,7 @@ a {
     width: 100%;
 }
 
-.form button {
+.auth-form button {
     display: block;
     justify-self: center;
     background-color: #2FAAC5;
@@ -84,32 +84,45 @@ a {
     margin: 0.5rem 0;
 }
 
-.sign-up-div fieldset {
+.auth-container fieldset {
     text-align: center;
     border: 1px none #AAA;
     border-top-style: solid;
     margin-top: 1rem;
 }
 
-.sign-up-div fieldset legend {
+.auth-container fieldset legend {
     padding: 0.3125rem 0.75rem;
 }
 
-.oauth2 {
+.auth-oauth2 {
     text-align: center;
 }
 
-.oauth2 img {
+.auth-oauth2 img {
     width: 2.1875rem;
     margin: 0.625rem 1.25rem;
 }
 
-.sign-up-div h5 {
+.auth-container > p {
     text-align: center;
     font-weight: normal;
+    font-size: 0.83rem;
 }
 
-.sign-up-div h5 a {
+.auth-container p a {
     font-weight: bold;
     color: #2FAAC5;
+}
+
+/* ---- LOGIN ---- */
+
+.auth-form input[id="password"] {
+    margin-bottom: 2px;
+}
+
+.auth-forgot-password {
+    text-align: right;
+    font-size: 0.83rem;
+    margin-bottom: 1.5rem;
 }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import GoogleIcon from '../assets/google-icon.svg'
-import FacebookIcon from '../assets/facebook-icon.svg'
+import FacebookIcon from '../assets/facebook-icon.svg';
+import GoogleIcon from '../assets/google-icon.svg';
 import { Link } from 'react-router-dom';
 
-const SignUp = () => {
+const Login = () => {
     return (
         <div className="auth-page">
             <div className="auth-container">
-                <h1>Sign Up</h1>
+                <h1>Login</h1>
 
                 <form method="POST" className="auth-form">
                     <label htmlFor="email">Email:</label><br/>
@@ -15,15 +15,13 @@ const SignUp = () => {
 
                     <label htmlFor="password">Password:</label><br/>
                     <input type="password" name="password" id="password"/><br/>
+                    <p className="auth-forgot-password"><Link to={null}>Forgot password?</Link></p>
 
-                    <label htmlFor="confirmPassword">Confirm password:</label><br/>
-                    <input type="password" name="confirm-password" id="confirm-password"/><br/>
-
-                    <button>Sign Up</button>
+                    <button>Login</button>
                 </form>
 
                 <fieldset>
-                    <legend>Or sign up with:</legend>
+                    <legend>Or login with:</legend>
                 </fieldset>
 
                 <div className="auth-oauth2">
@@ -31,10 +29,10 @@ const SignUp = () => {
                     <img src={GoogleIcon} alt="Google icon"/>
                 </div>
 
-                <p>Already have an account? <Link to="/login">Log in</Link></p>
+                <p>Don't have an account? <Link to="/sign-up">Sign up</Link></p>
             </div>
         </div>
     );
 };
 
-export default SignUp;
+export default Login;


### PR DESCRIPTION
### ✅ What does this PR do?
This PR adds the Login page UI to the routing system.

---

### 📋 Related Issue(s)
Closes #7 

---

### 🛠 Changes made
- Created `Login` page and routed it to `/login`
- Renamed `SignUp` page class names to more generic `auth-*` ones
- Updated CSS to match renamed class names
- Applied shared styling to `Login` page

---

### 📸 Screenshots (if applicable)
<img width="2560" height="1354" alt="image" src="https://github.com/user-attachments/assets/7bdb8c9b-f7a6-4b11-9644-0fe2ec13f1a1" />


---

### 🔎 How to test
1. Run `npm run dev`
2. Open http://localhost:5173/login
3. Verify:
    - The Login page is displayed and style as shown in the picture above
    - The redirect links at the bottom of each form correctly navigate between Sign Up and Login pages.

---

### 🧠 Notes
- This PR only covers the UI, the form submission, OAuth2, and Forgot pasword logic will be implemented in future PRs.
